### PR TITLE
Update README.md

### DIFF
--- a/README.md
+++ b/README.md
@@ -2,7 +2,7 @@
 ## Pico, Pico W and Pico 2 W powered HUB75 Matrix Drivers
 
 This repository is home to the MicroPython firmware and examples for
-Interstate 75, Interstate 75W and Interstate 75 .. 2W?.
+Interstate 75, Interstate 75W and Interstate 75 W (RP2350).
 
 ## Download Firmware
 


### PR DESCRIPTION
Your README ref'd the unknown name of the new version. You've changed it in other places and the product is now at https://shop.pimoroni.com/products/interstate-75-w?variant=54977948713339 under the name `Interstate 75 W (3350)`